### PR TITLE
created contribution_guidelines file

### DIFF
--- a/contribution_guidelines.md
+++ b/contribution_guidelines.md
@@ -1,0 +1,46 @@
+# Contributing to Dash of Spice
+
+## Contribution Prerequisites
+We welcome all contributions and feature requests to this project! All contributors must abide by our [code of conduct](<insert link to CoC file). 
+
+When contributing to this project, please feel free to discuss the change you wish to make via issue, email, or any other method with the maintainers before making a change.
+
+## Table of Contents
+* [What We Are Working On](#what-we-are-working-on)
+* [How to Submit Changes](#how-to-submit-changes)
+* [Posting Issues](#posting-issues)
+* [Maintaners](#maintaners)
+
+## What We Are Working On
+Check out the issues in our current milestone to get an idea of what's in the works!
+
+## How to Submit Changes
+If you would like to contribute to our project or fix a bug, you are welcome to follow these steps to make your changes:
+1. Please [open up an issue](https://github.com/UBC-MDS/dash_of_spice/issues) and see the section on posting issues. 
+2. Fork this repository.
+3. Make your changes.
+4. Submit a pull request. Please document your pull request accordingly.
+
+## Posting Issues
+
+Please follow this issue template for a more efficient and effective issue.
+
+```
+[Title of the issue or feature request]
+
+Detailed description of the issue. Put as much information as you can, potentially
+with images showing the issue or mockups of the proposed feature.
+
+If it's an issue, add the steps to reproduce the issue like this:
+  
+Steps to reproduce:
+
+1. step 1
+2. step 2
+3. ...
+
+Description of suggestions and potential fixes you would like to see.
+```
+
+## Maintaners
+This repository is currently maintained by @rachelywong, @ChadNeald, @cmmclaug, and @Saule-Atymtayeva. 

--- a/contribution_guidelines.md
+++ b/contribution_guidelines.md
@@ -1,7 +1,7 @@
 # Contributing to Dash of Spice
 
 ## Contribution Prerequisites
-We welcome all contributions and feature requests to this project! All contributors must abide by our [code of conduct](<insert link to CoC file). 
+We welcome all contributions and feature requests to this project! All contributors must abide by our [code of conduct](https://github.com/UBC-MDS/dash_of_spice/blob/main/CODE_OF_CONDUCT.md). 
 
 When contributing to this project, please feel free to discuss the change you wish to make via issue, email, or any other method with the maintainers before making a change.
 


### PR DESCRIPTION
For the code of conduct link in the contributing guidelines, should I just re-edit it once we’ve merged milestone 1 with our master repo to add the correct link? 